### PR TITLE
Change image angle

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -213,7 +213,8 @@
           slider.classList.remove('rv-slider-error');
           control.style.animation = '';
           slider.style.left = 0;
-          img.style.transform = 'rotate(' + currentAngle + 'deg)';
+          img.style.transform = 'rotate(' + RandomAngle(Settings.tolerance) + 'deg)';
+          currentAngle = getImgAngle();
           slider.style.transition =
             'background .2s ease-in-out,border-color .2s ease-in-out,box-shadow .2s ease-in-out,left .5s ease-in-out';
           img.style.transition = 'transform .5s ease-in-out';


### PR DESCRIPTION
When a verification fails, the angle should be changed. This helps prevents spamming from guessing the angle incrementally by brute force. This PR fixes that so that the angle changes on failure.